### PR TITLE
chore(ci): upgrade checkout action to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -38,7 +38,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- upgrade `actions/checkout` from `v4` to `v5` in CI
- keep `actions/setup-node@v6` and project Node 24 setup unchanged
- remove the remaining GitHub Actions Node 20 runtime deprecation warning source

## Validation
- `git diff --check -- .github/workflows/ci.yml`
- wait for GitHub Actions CI on this PR
