### PR TITLE
[codex] Add full-site RSS feed

### DIFF
--- a/src/plugin/plugin-content-blog/fullSiteFeed.js
+++ b/src/plugin/plugin-content-blog/fullSiteFeed.js
@@ -1,0 +1,447 @@
+const fs = require('fs');
+const path = require('path');
+const matter = require('gray-matter');
+const { Feed } = require('feed');
+const { load: loadHtml } = require('cheerio');
+
+const FEED_FILE_NAMES = {
+  rss: 'rss.xml',
+  atom: 'atom.xml',
+  json: 'feed.json',
+};
+
+function toPosixPath(filePath) {
+  return filePath.replace(/\\/g, '/');
+}
+
+function trimLeadingSlash(value) {
+  return value.replace(/^\/+/, '');
+}
+
+function trimTrailingSlash(value) {
+  return value.replace(/\/+$/, '');
+}
+
+function joinUrlPath(...parts) {
+  const normalized = parts
+    .filter(Boolean)
+    .map((part, index) => {
+      const posixPart = toPosixPath(String(part));
+      if (index === 0) {
+        return trimTrailingSlash(posixPart) || '/';
+      }
+      return trimLeadingSlash(trimTrailingSlash(posixPart));
+    })
+    .filter((part, index) => !(index > 0 && !part));
+
+  if (normalized.length === 0) {
+    return '/';
+  }
+
+  return normalized.reduce((acc, part, index) => {
+    if (index === 0) {
+      return part;
+    }
+    return `${trimTrailingSlash(acc)}/${part}`;
+  });
+}
+
+function normalizeFeedTypes(type) {
+  if (!type) {
+    return [];
+  }
+
+  if (type === 'all') {
+    return ['rss', 'atom', 'json'];
+  }
+
+  return Array.isArray(type) ? type : [type];
+}
+
+function toAbsoluteUrl(siteConfig, permalink) {
+  return new URL(permalink, siteConfig.url).toString();
+}
+
+function formatDate(dateValue) {
+  if (!dateValue) {
+    return null;
+  }
+
+  const date = dateValue instanceof Date ? dateValue : new Date(dateValue);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function toCategories(tags = []) {
+  return tags
+    .map((tag) => {
+      if (typeof tag === 'string') {
+        return tag;
+      }
+      return tag?.label || tag?.name || '';
+    })
+    .filter(Boolean)
+    .map((tag) => ({ name: tag, term: tag }));
+}
+
+function extractDescription(frontMatterDescription, content, maxLength = 160) {
+  if (frontMatterDescription?.trim()) {
+    return frontMatterDescription.length > maxLength
+      ? `${frontMatterDescription.substring(0, maxLength).replace(/\s+\S*$/, '')}...`
+      : frontMatterDescription;
+  }
+
+  const text = content
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/`[^`]*`/g, ' ')
+    .replace(/!\[[^\]]*]\([^)]+\)/g, ' ')
+    .replace(/\[([^\]]+)]\([^)]+\)/g, '$1')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/(\*\*?|__?)([^*_]+)\1/g, '$2')
+    .replace(/^\s*[-*+\d.]\s+/gm, ' ')
+    .replace(/^>\s?/gm, '')
+    .replace(/^---+$/gm, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const truncated = text.substring(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(' ');
+  return lastSpace > maxLength * 0.7
+    ? `${truncated.substring(0, lastSpace)}...`
+    : `${truncated}...`;
+}
+
+function resolveDocPermalink(relativePath, frontMatter, locale, defaultLocale) {
+  const pathPrefix = locale === defaultLocale ? '/docs' : `/${locale}/docs`;
+  const normalizedRelativePath = toPosixPath(relativePath).replace(/\.mdx?$/, '');
+  const slugValue = typeof frontMatter.slug === 'string' ? frontMatter.slug.trim() : '';
+
+  if (!slugValue) {
+    return joinUrlPath(pathPrefix, normalizedRelativePath);
+  }
+
+  if (slugValue.startsWith('/')) {
+    return joinUrlPath(pathPrefix, slugValue);
+  }
+
+  const pathSegments = normalizedRelativePath.split('/');
+  pathSegments[pathSegments.length - 1] = slugValue;
+  return joinUrlPath(pathPrefix, pathSegments.join('/'));
+}
+
+function getDocsDir(siteDir, locale, defaultLocale) {
+  if (locale === defaultLocale) {
+    return path.join(siteDir, 'docs');
+  }
+
+  return path.join(siteDir, 'i18n', locale, 'docusaurus-plugin-content-docs', 'current');
+}
+
+function collectDocsFeedItems({ siteDir, locale, defaultLocale, siteConfig }) {
+  const docsDir = getDocsDir(siteDir, locale, defaultLocale);
+  if (!fs.existsSync(docsDir)) {
+    return [];
+  }
+
+  const items = [];
+
+  function traverse(currentDir) {
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        traverse(fullPath);
+        continue;
+      }
+
+      if (!entry.isFile() || !/\.mdx?$/.test(entry.name)) {
+        continue;
+      }
+
+      const fileBaseName = entry.name.replace(/\.mdx?$/, '');
+      if (fileBaseName === 'intro' || entry.name.startsWith('_')) {
+        continue;
+      }
+
+      try {
+        const source = fs.readFileSync(fullPath, 'utf8');
+        const { data, content } = matter(source);
+        const date = formatDate(data.date);
+
+        if (!date || data.draft || data.unlisted) {
+          continue;
+        }
+
+        const relativePath = toPosixPath(path.relative(docsDir, fullPath));
+        const permalink = resolveDocPermalink(relativePath, data, locale, defaultLocale);
+        const title =
+          data.title ||
+          data.sidebar_label ||
+          relativePath.replace(/\.mdx?$/, '');
+        const description = extractDescription(data.description, content);
+        const absoluteUrl = toAbsoluteUrl(siteConfig, permalink);
+
+        items.push({
+          title,
+          id: absoluteUrl,
+          link: absoluteUrl,
+          date,
+          description,
+          content: description,
+          category: toCategories(data.tags),
+          permalink,
+          sourceType: 'doc',
+        });
+      } catch (error) {
+        console.warn(`[FullSiteFeed] Failed to read doc ${fullPath}:`, error.message);
+      }
+    }
+  }
+
+  traverse(docsDir);
+  return items;
+}
+
+function collectBlogFeedItems({ blogPosts, siteConfig }) {
+  return blogPosts
+    .filter((post) => {
+      const frontMatter = post.metadata.frontMatter || {};
+      return !frontMatter.draft && !frontMatter.unlisted;
+    })
+    .map((post) => {
+      const {
+        title,
+        permalink,
+        date: rawDate,
+        description,
+        tags,
+        authors,
+      } = post.metadata;
+      const date = formatDate(rawDate);
+      const absoluteUrl = toAbsoluteUrl(siteConfig, permalink);
+      const item = {
+        title,
+        id: absoluteUrl,
+        link: absoluteUrl,
+        date,
+        description,
+        content: description,
+        category: toCategories(tags),
+        permalink,
+        sourceType: 'blog',
+      };
+
+      const feedAuthors = (authors || []).map((author) => ({
+        name: author.name,
+        link: author.url,
+        email: author.email,
+      }));
+      if (feedAuthors.length > 0) {
+        item.author = feedAuthors;
+      }
+
+      return item;
+    })
+    .filter((item) => item.date);
+}
+
+function collectFullSiteFeedItems({
+  blogPosts,
+  siteDir,
+  locale,
+  defaultLocale,
+  siteConfig,
+}) {
+  const blogItems = collectBlogFeedItems({ blogPosts, siteConfig });
+  const docItems = collectDocsFeedItems({
+    siteDir,
+    locale,
+    defaultLocale,
+    siteConfig,
+  });
+
+  return [...blogItems, ...docItems].sort(
+    (a, b) => b.date.getTime() - a.date.getTime(),
+  );
+}
+
+function getRouteCandidates(permalink, siteConfig, locale, defaultLocale) {
+  const candidates = new Set();
+  const normalizedPermalink = trimLeadingSlash(permalink);
+  candidates.add(normalizedPermalink);
+
+  const baseUrl = siteConfig.baseUrl || '/';
+  const normalizedBaseUrl = trimLeadingSlash(trimTrailingSlash(baseUrl));
+  if (normalizedBaseUrl && normalizedPermalink.startsWith(`${normalizedBaseUrl}/`)) {
+    candidates.add(normalizedPermalink.slice(normalizedBaseUrl.length + 1));
+  }
+
+  if (locale !== defaultLocale && normalizedPermalink.startsWith(`${locale}/`)) {
+    candidates.add(normalizedPermalink.slice(locale.length + 1));
+  }
+
+  return Array.from(candidates).filter(Boolean);
+}
+
+function findOutputHtmlPath({ outDir, permalink, siteConfig, locale, defaultLocale }) {
+  const routeCandidates = getRouteCandidates(permalink, siteConfig, locale, defaultLocale);
+
+  for (const routeCandidate of routeCandidates) {
+    const indexPath = path.join(outDir, routeCandidate, 'index.html');
+    if (fs.existsSync(indexPath)) {
+      return indexPath;
+    }
+
+    const htmlPath = path.join(outDir, `${routeCandidate}.html`);
+    if (fs.existsSync(htmlPath)) {
+      return htmlPath;
+    }
+  }
+
+  return null;
+}
+
+function readRenderedContent({
+  outDir,
+  item,
+  siteConfig,
+  locale,
+  defaultLocale,
+}) {
+  if (!outDir || !item.permalink) {
+    return item.content;
+  }
+
+  const htmlPath = findOutputHtmlPath({
+    outDir,
+    permalink: item.permalink,
+    siteConfig,
+    locale,
+    defaultLocale,
+  });
+
+  if (!htmlPath) {
+    return item.content;
+  }
+
+  try {
+    const html = fs.readFileSync(htmlPath, 'utf8');
+    const $ = loadHtml(html);
+    const selector =
+      item.sourceType === 'blog'
+        ? '#__blog-post-container'
+        : '.theme-doc-markdown, article .markdown';
+    const article = $(selector).first();
+
+    if (!article.length) {
+      return item.content;
+    }
+
+    const itemUrl = item.link;
+    article.find('a[href], img[src]').each((_, element) => {
+      const attributes = element.attribs;
+      if (attributes.href) {
+        attributes.href = new URL(attributes.href, itemUrl).toString();
+      }
+      if (attributes.src) {
+        attributes.src = new URL(attributes.src, itemUrl).toString();
+      }
+    });
+
+    return article.html() || item.content;
+  } catch (error) {
+    console.warn(`[FullSiteFeed] Failed to read rendered HTML for ${item.link}:`, error.message);
+    return item.content;
+  }
+}
+
+function createFeed({ items, routeBasePath, locale, siteConfig, feedOptions }) {
+  const feedLink = toAbsoluteUrl(siteConfig, joinUrlPath(siteConfig.baseUrl || '/', routeBasePath));
+  const feed = new Feed({
+    id: feedLink,
+    title: feedOptions.title || siteConfig.title,
+    updated: items[0]?.date,
+    language: feedOptions.language || locale,
+    link: feedLink,
+    description: feedOptions.description || `${siteConfig.title} articles`,
+    favicon: siteConfig.favicon
+      ? toAbsoluteUrl(siteConfig, joinUrlPath(siteConfig.baseUrl || '/', siteConfig.favicon))
+      : undefined,
+    copyright: feedOptions.copyright || `Copyright ${siteConfig.title}`,
+  });
+
+  items.forEach((item) => feed.addItem(item));
+  return feed;
+}
+
+async function writeFullSiteFeedFiles({
+  items,
+  outDir,
+  routeBasePath,
+  locale,
+  defaultLocale,
+  siteConfig,
+  feedOptions,
+}) {
+  const feedTypes = normalizeFeedTypes(feedOptions.type);
+  if (items.length === 0 || feedTypes.length === 0) {
+    return;
+  }
+
+  const feedItems = items.map((item) => ({
+    ...item,
+    content: readRenderedContent({
+      outDir,
+      item,
+      siteConfig,
+      locale,
+      defaultLocale,
+    }),
+  }));
+  const feed = createFeed({
+    items: feedItems,
+    routeBasePath,
+    locale,
+    siteConfig,
+    feedOptions,
+  });
+  const outputDir = path.join(outDir, routeBasePath);
+
+  await fs.promises.mkdir(outputDir, { recursive: true });
+
+  await Promise.all(
+    feedTypes.map(async (feedType) => {
+      const fileName = FEED_FILE_NAMES[feedType];
+      if (!fileName) {
+        return;
+      }
+
+      const outputPath = path.join(outputDir, fileName);
+      const content =
+        feedType === 'rss'
+          ? feed.rss2()
+          : feedType === 'atom'
+            ? feed.atom1()
+            : feed.json1();
+
+      await fs.promises.writeFile(outputPath, content, 'utf8');
+    }),
+  );
+}
+
+module.exports = {
+  collectFullSiteFeedItems,
+  writeFullSiteFeedFiles,
+  _internals: {
+    collectDocsFeedItems,
+    collectBlogFeedItems,
+    joinUrlPath,
+    resolveDocPermalink,
+  },
+};

--- a/src/plugin/plugin-content-blog/fullSiteFeed.test.js
+++ b/src/plugin/plugin-content-blog/fullSiteFeed.test.js
@@ -1,0 +1,145 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  collectFullSiteFeedItems,
+  writeFullSiteFeedFiles,
+} = require('./fullSiteFeed');
+
+function createTempSite() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'eave-feed-'));
+}
+
+function writeMarkdown(filePath, source) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, source, 'utf8');
+}
+
+const siteConfig = {
+  url: 'https://eaveluo.com',
+  baseUrl: '/',
+  title: 'Eave Luo',
+  favicon: 'img/favicon.ico',
+};
+
+test('collectFullSiteFeedItems merges blog posts and dated docs sorted newest first', () => {
+  const siteDir = createTempSite();
+
+  writeMarkdown(
+    path.join(siteDir, 'docs', 'ai', 'agent.md'),
+    `---
+title: Agent Notes
+description: Notes about agents
+date: 2026-04-10
+tags: [AI, Agent]
+---
+
+# Agent Notes
+
+Docs body.
+`,
+  );
+  writeMarkdown(
+    path.join(siteDir, 'docs', 'ai', 'intro.md'),
+    `---
+title: AI Intro
+date: 2026-05-01
+---
+
+# Intro pages are not articles.
+`,
+  );
+  writeMarkdown(
+    path.join(siteDir, 'docs', 'operation', 'hidden.md'),
+    `---
+title: Hidden
+date: 2026-05-02
+unlisted: true
+---
+
+# Hidden
+`,
+  );
+
+  const items = collectFullSiteFeedItems({
+    blogPosts: [
+      {
+        metadata: {
+          title: 'Website 0.8.0',
+          permalink: '/blog/website/0.8.0',
+          date: new Date('2026-04-18T00:00:00.000Z'),
+          description: 'Release notes',
+          frontMatter: {},
+          tags: [{ label: 'Website' }],
+          authors: [{ name: 'Eave Luo', url: 'https://eaveluo.com' }],
+        },
+      },
+      {
+        metadata: {
+          title: 'Draft Blog',
+          permalink: '/blog/draft',
+          date: new Date('2026-05-01T00:00:00.000Z'),
+          description: 'Draft',
+          frontMatter: { draft: true },
+          tags: [],
+          authors: [],
+        },
+      },
+    ],
+    siteDir,
+    locale: 'zh-CN',
+    defaultLocale: 'zh-CN',
+    siteConfig,
+  });
+
+  assert.deepEqual(
+    items.map((item) => item.title),
+    ['Website 0.8.0', 'Agent Notes'],
+  );
+  assert.equal(items[0].link, 'https://eaveluo.com/blog/website/0.8.0');
+  assert.equal(items[1].link, 'https://eaveluo.com/docs/ai/agent');
+  assert.deepEqual(items[1].category, [
+    { name: 'AI', term: 'AI' },
+    { name: 'Agent', term: 'Agent' },
+  ]);
+});
+
+test('writeFullSiteFeedFiles writes configured feeds under the blog route path', async () => {
+  const siteDir = createTempSite();
+  const outDir = path.join(siteDir, 'build');
+
+  await writeFullSiteFeedFiles({
+    items: [
+      {
+        title: 'All Articles Entry',
+        id: 'https://eaveluo.com/docs/ai/agent',
+        link: 'https://eaveluo.com/docs/ai/agent',
+        date: new Date('2026-04-10T00:00:00.000Z'),
+        description: 'Notes about agents',
+        content: 'Notes about agents',
+        category: [{ name: 'AI', term: 'AI' }],
+      },
+    ],
+    outDir,
+    routeBasePath: 'blog',
+    locale: 'zh-CN',
+    siteConfig,
+    feedOptions: {
+      type: ['rss', 'atom', 'json'],
+      title: 'Eave Luo',
+      description: 'All articles from Eave Luo',
+      copyright: 'Copyright Eave Luo',
+    },
+  });
+
+  const rss = fs.readFileSync(path.join(outDir, 'blog', 'rss.xml'), 'utf8');
+  const atom = fs.readFileSync(path.join(outDir, 'blog', 'atom.xml'), 'utf8');
+  const json = fs.readFileSync(path.join(outDir, 'blog', 'feed.json'), 'utf8');
+
+  assert.match(rss, /All Articles Entry/);
+  assert.match(atom, /All Articles Entry/);
+  assert.match(json, /All Articles Entry/);
+});

--- a/src/plugin/plugin-content-blog/index.js
+++ b/src/plugin/plugin-content-blog/index.js
@@ -5,6 +5,10 @@
 const blogPluginExports = require('@docusaurus/plugin-content-blog');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { default: blogPlugin } = blogPluginExports;
+const {
+  collectFullSiteFeedItems,
+  writeFullSiteFeedFiles,
+} = require('./fullSiteFeed');
 
 /**
  * 增强的博客插件 - 包装原始插件并注入全局数据
@@ -14,6 +18,9 @@ const { default: blogPlugin } = blogPluginExports;
  */
 async function blogPluginEnhanced(context, options) {
   const blogPluginInstance = await blogPlugin(context, options);
+  const { i18n, siteConfig, siteDir } = context;
+  const currentLocale = i18n.currentLocale;
+  const defaultLocale = i18n.defaultLocale;
 
   return {
     ...blogPluginInstance,
@@ -49,6 +56,38 @@ async function blogPluginEnhanced(context, options) {
         })),
         postNum: blogPosts.length,
         tagNum: Object.keys(blogTags).length,
+      });
+    },
+
+    async postBuild(props) {
+      if (blogPluginInstance.postBuild) {
+        await blogPluginInstance.postBuild(props);
+      }
+
+      const feedOptions = options.feedOptions || {};
+      if (!feedOptions.type) {
+        return;
+      }
+
+      const items = collectFullSiteFeedItems({
+        blogPosts: props.content.blogPosts,
+        siteDir,
+        locale: currentLocale,
+        defaultLocale,
+        siteConfig,
+      });
+
+      await writeFullSiteFeedFiles({
+        items,
+        outDir: props.outDir,
+        routeBasePath: options.routeBasePath || 'blog',
+        locale: currentLocale,
+        defaultLocale,
+        siteConfig,
+        feedOptions: {
+          ...feedOptions,
+          description: feedOptions.description || `${siteConfig.title} articles`,
+        },
       });
     },
   };


### PR DESCRIPTION
## Summary

- Add a custom full-site feed generator for the wrapped Docusaurus blog plugin.
- Keep the existing subscription URLs under `/blog/rss.xml`, `/blog/atom.xml`, and `/blog/feed.json` while replacing their content with blog + dated docs articles.
- Support both default `zh-CN` output and localized `en` output, including rendered article HTML when build output is available.
- Add Node tests for mixed blog/docs feed collection and writing feed files under the blog route path.

## Why

The site already exposed RSS through the blog plugin, but that feed only included blog posts. The homepage and docs structure treat dated docs as articles too, so subscribers should receive those updates from the same existing `/blog/rss.xml` URL.

## Validation

- `node --test src\plugin\plugin-content-blog\fullSiteFeed.test.js`
- `npm run typecheck`
- `npm run build`

Build completed for both `zh-CN` and `en`. Existing Docusaurus warnings about SWC/Babel config and `vscode-languageserver-types` remain unchanged.