### PR TITLE
[codex] Localize footer RSS links

### DIFF
--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Translate, { translate } from '@docusaurus/Translate';
 import { ArrowUpRight, Heart, Mail, Rss } from 'lucide-react';
+import { getNavLinks } from './links';
 import styles from './styles.module.css';
 
 // 备案信息
@@ -12,29 +14,13 @@ const policeBeian = '湘公网安备43011102002452号';
 // 当前年份
 const currentYear = new Date().getFullYear();
 
-// 导航链接数据
-const getNavLinks = () => [
-  {
-    title: translate({ id: 'footer.knowledge', message: '知识库' }),
-    links: [
-      { label: translate({ id: 'footer.frontend', message: '前端开发' }), to: '/docs/front-end/intro' },
-      { label: translate({ id: 'footer.backend', message: '后端开发' }), to: '/docs/back-end/intro' },
-      { label: translate({ id: 'footer.operation', message: '运维部署' }), to: '/docs/operation/intro' },
-      { label: translate({ id: 'footer.ai', message: '人工智能' }), to: '/docs/ai/intro' },
-    ],
-  },
-  {
-    title: translate({ id: 'footer.more', message: '更多' }),
-    links: [
-      { label: translate({ id: 'footer.blog', message: '博客文章' }), to: '/blog' },
-      { label: translate({ id: 'footer.about', message: '关于我' }), to: '/about' },
-      { label: translate({ id: 'footer.rss', message: 'RSS 订阅' }), href: '/blog/rss.xml', external: true },
-    ],
-  },
-];
+const translateFooterMessage = (id: string, message: string) =>
+  translate({ id, message });
 
 function Footer(): React.ReactElement | null {
   const { siteConfig } = useDocusaurusContext();
+  const rssHref = useBaseUrl('/blog/rss.xml');
+  const navLinks = getNavLinks(rssHref, translateFooterMessage);
 
   return (
     <footer className={styles.footer}>
@@ -107,7 +93,7 @@ function Footer(): React.ReactElement | null {
                 </svg>
               </a>
               <a
-                href="/blog/rss.xml"
+                href={rssHref}
                 className={styles.socialLink}
                 aria-label="RSS"
               >
@@ -118,7 +104,7 @@ function Footer(): React.ReactElement | null {
 
           {/* 右侧：导航链接 */}
           <div className={styles.right}>
-            {getNavLinks().map((section) => (
+            {navLinks.map((section) => (
               <div key={section.title} className={styles.linkSection}>
                 <h3 className={styles.linkTitle}>{section.title}</h3>
                 <ul className={styles.linkList}>

--- a/src/theme/Footer/links.test.js
+++ b/src/theme/Footer/links.test.js
@@ -1,0 +1,29 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const ts = require('typescript');
+
+require.extensions['.ts'] = (module, filename) => {
+  const source = fs.readFileSync(filename, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: filename,
+  });
+
+  module._compile(outputText, filename);
+};
+
+const { getNavLinks } = require('./links.ts');
+
+test('getNavLinks uses the locale-aware RSS href provided by the footer', () => {
+  const rssHref = '/en/blog/rss.xml';
+  const sections = getNavLinks(rssHref, (id, message) => message);
+  const moreSection = sections.find((section) => section.id === 'more');
+  const rssLink = moreSection.links.find((link) => link.id === 'rss');
+
+  assert.equal(rssLink.href, rssHref);
+  assert.equal(rssLink.external, true);
+});

--- a/src/theme/Footer/links.ts
+++ b/src/theme/Footer/links.ts
@@ -1,0 +1,50 @@
+export type FooterTranslateMessage = (id: string, message: string) => string;
+
+export type FooterLink =
+  | {
+      id: string;
+      label: string;
+      to: string;
+      href?: never;
+      external?: never;
+    }
+  | {
+      id: string;
+      label: string;
+      href: string;
+      external: true;
+      to?: never;
+    };
+
+export type FooterLinkSection = {
+  id: string;
+  title: string;
+  links: FooterLink[];
+};
+
+export function getNavLinks(
+  rssHref: string,
+  translateMessage: FooterTranslateMessage,
+): FooterLinkSection[] {
+  return [
+    {
+      id: 'knowledge',
+      title: translateMessage('footer.knowledge', '知识库'),
+      links: [
+        { id: 'frontend', label: translateMessage('footer.frontend', '前端开发'), to: '/docs/front-end/intro' },
+        { id: 'backend', label: translateMessage('footer.backend', '后端开发'), to: '/docs/back-end/intro' },
+        { id: 'operation', label: translateMessage('footer.operation', '运维部署'), to: '/docs/operation/intro' },
+        { id: 'ai', label: translateMessage('footer.ai', '人工智能'), to: '/docs/ai/intro' },
+      ],
+    },
+    {
+      id: 'more',
+      title: translateMessage('footer.more', '更多'),
+      links: [
+        { id: 'blog', label: translateMessage('footer.blog', '博客文章'), to: '/blog' },
+        { id: 'about', label: translateMessage('footer.about', '关于我'), to: '/about' },
+        { id: 'rss', label: translateMessage('footer.rss', 'RSS 订阅'), href: rssHref, external: true },
+      ],
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Generate footer RSS links with Docusaurus `useBaseUrl('/blog/rss.xml')` instead of a hardcoded root path.
- Extract footer navigation link data into a typed helper so the RSS href can be injected per locale.
- Add a Node test covering locale-aware RSS href injection.

## Why

The footer RSS buttons were hardcoded to `/blog/rss.xml`, so English pages linked users back to the Chinese/default feed. This keeps SSG behavior because Docusaurus resolves the locale-aware URL during each locale build.

## Validation

- `node --test src\theme\Footer\links.test.js`
- `npm run typecheck`
- `npm run build`
- Checked build output: `build/index.html` contains `/blog/rss.xml`, `build/en/index.html` contains `/en/blog/rss.xml`, and English output no longer contains root `/blog/rss.xml` footer links.

Existing Docusaurus warnings about SWC/Babel config and `vscode-languageserver-types` remain unchanged.