### PR TITLE
[codex] show article dates on docs pages

### DIFF
--- a/src/components/ArticleDate/format.test.js
+++ b/src/components/ArticleDate/format.test.js
@@ -1,0 +1,44 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const test = require('node:test');
+const ts = require('typescript');
+
+require.extensions['.ts'] = (module, filename) => {
+  const source = fs.readFileSync(filename, 'utf8');
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+    },
+    fileName: filename,
+  });
+
+  module._compile(outputText, filename);
+};
+
+const { formatArticleDate, getArticleDateTime } = require('./format.ts');
+
+test('formatArticleDate keeps zh-CN article dates simple', () => {
+  assert.equal(formatArticleDate('2026-04-08', 'zh-CN'), '2026-04-08');
+});
+
+test('formatArticleDate uses a concise English date', () => {
+  assert.equal(formatArticleDate('2026-04-08', 'en'), 'Apr 8, 2026');
+});
+
+test('formatArticleDate normalizes timestamp input in UTC', () => {
+  assert.equal(
+    formatArticleDate('2024-06-28T09:10:57.000Z', 'zh-CN'),
+    '2024-06-28'
+  );
+});
+
+test('formatArticleDate ignores empty or invalid dates', () => {
+  assert.equal(formatArticleDate('', 'zh-CN'), null);
+  assert.equal(formatArticleDate('not-a-date', 'en'), null);
+});
+
+test('getArticleDateTime returns a stable machine-readable date', () => {
+  assert.equal(getArticleDateTime('2026-04-08T09:10:57.000Z'), '2026-04-08');
+  assert.equal(getArticleDateTime('not-a-date'), undefined);
+});

--- a/src/components/ArticleDate/format.ts
+++ b/src/components/ArticleDate/format.ts
@@ -1,0 +1,34 @@
+function parseArticleDate(date: unknown): Date | null {
+  if (!date) {
+    return null;
+  }
+
+  const parsed = date instanceof Date ? date : new Date(String(date));
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function getArticleDateTime(date: unknown): string | undefined {
+  const parsed = parseArticleDate(date);
+  return parsed?.toISOString().slice(0, 10);
+}
+
+export function formatArticleDate(
+  date: unknown,
+  locale: string
+): string | null {
+  const parsed = parseArticleDate(date);
+  if (!parsed) {
+    return null;
+  }
+
+  if (locale.startsWith('en')) {
+    return new Intl.DateTimeFormat('en', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC',
+    }).format(parsed);
+  }
+
+  return parsed.toISOString().slice(0, 10);
+}

--- a/src/components/ArticleDate/index.tsx
+++ b/src/components/ArticleDate/index.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+
+import { formatArticleDate, getArticleDateTime } from './format';
+import styles from './styles.module.css';
+
+type Props = {
+  date: unknown;
+};
+
+export default function ArticleDate({ date }: Props): ReactNode {
+  const { i18n } = useDocusaurusContext();
+  const formattedDate = formatArticleDate(date, i18n.currentLocale);
+  const dateTime = getArticleDateTime(date);
+
+  if (!formattedDate || !dateTime) {
+    return null;
+  }
+
+  return (
+    <p className={styles.articleDate}>
+      <time dateTime={dateTime}>{formattedDate}</time>
+    </p>
+  );
+}

--- a/src/components/ArticleDate/styles.module.css
+++ b/src/components/ArticleDate/styles.module.css
@@ -1,0 +1,11 @@
+.articleDate {
+  margin-top: -0.35rem;
+  margin-bottom: 1.35rem;
+  color: var(--ifm-color-emphasis-600);
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.articleDate time {
+  font-variant-numeric: tabular-nums;
+}

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React, { type ComponentProps, type ReactNode } from 'react';
+import { MDXProvider } from '@mdx-js/react';
+import clsx from 'clsx';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+import Heading from '@theme/Heading';
+import MDXComponents from '@theme/MDXComponents';
+import MDXHeading from '@theme/MDXComponents/Heading';
+import type { Props } from '@theme/DocItem/Content';
+
+import ArticleDate from '@site/src/components/ArticleDate';
+
+/**
+ Title can be declared inside md content or declared through
+ front matter and added manually. To make both cases consistent,
+ the added title is added under the same div.markdown block
+ See https://github.com/facebook/docusaurus/pull/4882#issuecomment-853021120
+
+ We render a "synthetic title" if:
+ - user doesn't ask to hide it with front matter
+ - the markdown content does not already contain a top-level h1 heading
+*/
+function useSyntheticTitle(): string | null {
+  const { metadata, frontMatter, contentTitle } = useDoc();
+  const shouldRender =
+    !frontMatter.hide_title && typeof contentTitle === 'undefined';
+  if (!shouldRender) {
+    return null;
+  }
+  return metadata.title;
+}
+
+function DocMDXContentWithDate({
+  children,
+  date,
+  shouldRenderDateAfterFirstH1,
+}: {
+  children: ReactNode;
+  date: unknown;
+  shouldRenderDateAfterFirstH1: boolean;
+}): ReactNode {
+  let hasRenderedFirstH1Date = false;
+
+  const components = {
+    ...MDXComponents,
+    h1: (props: ComponentProps<'h1'>) => {
+      const shouldRenderDate =
+        shouldRenderDateAfterFirstH1 && !hasRenderedFirstH1Date;
+      hasRenderedFirstH1Date = true;
+
+      return (
+        <>
+          <MDXHeading as="h1" {...props} />
+          {shouldRenderDate && <ArticleDate date={date} />}
+        </>
+      );
+    },
+  };
+
+  return <MDXProvider components={components}>{children}</MDXProvider>;
+}
+
+export default function DocItemContent({ children }: Props): ReactNode {
+  const syntheticTitle = useSyntheticTitle();
+  const { frontMatter } = useDoc();
+  const articleDate = (frontMatter as { date?: unknown }).date;
+
+  return (
+    <div className={clsx(ThemeClassNames.docs.docMarkdown, 'markdown')}>
+      {syntheticTitle && (
+        <header>
+          <Heading as="h1">{syntheticTitle}</Heading>
+          <ArticleDate date={articleDate} />
+        </header>
+      )}
+      <DocMDXContentWithDate
+        date={articleDate}
+        shouldRenderDateAfterFirstH1={!syntheticTitle}
+      >
+        {children}
+      </DocMDXContentWithDate>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add an `ArticleDate` component that formats doc `date` front matter per locale.
- Swizzle `DocItem/Content` so docs pages render the article date under the page title during SSG.
- Cover the date formatter with focused node tests.

## Validation

- `node --test src\components\ArticleDate\format.test.js`
- `npm run typecheck`
- `npm run build`
- Checked built HTML for zh-CN and en docs pages contains the expected `<time>` output.

Note: `npm run build` still reports the existing Mermaid dependency-chain warning from `vscode-languageserver-types`, unrelated to this change.