### PR TITLE
[codex] homepage background option B: editorial canvas

### DIFF
--- a/src/components/Homepage/BackgroundEffects/index.tsx
+++ b/src/components/Homepage/BackgroundEffects/index.tsx
@@ -1,32 +1,13 @@
 import { memo } from 'react';
 import styles from './styles.module.css';
 
-/**
- * 优化版 CSS 背景效果
- * - 柔和渐变，不干扰阅读
- * - 缓慢呼吸动画，增加动态感
- * - 底部遮罩确保文字可读性
- */
 function BackgroundEffects() {
   return (
     <div className={styles.background} aria-hidden="true">
-      {/* 基础渐变背景 */}
-      <div className={styles.gradientBase} />
-      
-      {/* 呼吸光晕 */}
-      <div className={styles.glowOrb} />
-      <div className={styles.glowOrbSecondary} />
-      
-      {/* 极淡网格 */}
-      <div className={styles.gridLines} />
-      
-      {/* 微妙浮动点 */}
-      <div className={styles.floatingDots} />
-      
-      {/* 装饰圆环 */}
-      <div className={styles.decorativeRing} />
-      
-      {/* 可读性遮罩 */}
+      <div className={styles.canvas} />
+      <div className={styles.editorialBlocks} />
+      <div className={styles.ruleLines} />
+      <div className={styles.cornerMarks} />
       <div className={styles.readabilityMask} />
     </div>
   );

--- a/src/components/Homepage/BackgroundEffects/styles.module.css
+++ b/src/components/Homepage/BackgroundEffects/styles.module.css
@@ -1,289 +1,104 @@
-/* 优化版 CSS 背景效果 - 动态但不干扰阅读 */
-
 .background {
   position: fixed;
   inset: 0;
   pointer-events: none;
   z-index: -1;
   overflow: hidden;
+  background: #fcfdfc;
 }
 
-/* ===== 柔和渐变背景 ===== */
-.gradientBase {
-  position: absolute;
-  inset: 0;
-  background: 
-    radial-gradient(ellipse 80% 50% at 50% -20%, rgba(46, 133, 85, 0.08), transparent),
-    radial-gradient(ellipse 60% 40% at 80% 50%, rgba(37, 194, 160, 0.05), transparent),
-    radial-gradient(ellipse 50% 30% at 20% 80%, rgba(46, 133, 85, 0.06), transparent);
-}
-
-/* ===== 缓慢呼吸的光晕 ===== */
-.glowOrb {
-  position: absolute;
-  width: 500px;
-  height: 500px;
-  border-radius: 50%;
-  background: radial-gradient(
-    circle at center,
-    rgba(46, 133, 85, 0.12) 0%,
-    rgba(46, 133, 85, 0.04) 40%,
-    transparent 70%
-  );
-  top: 10%;
-  right: -150px;
-  animation: breathe 15s ease-in-out infinite;
-  will-change: opacity, transform;
-}
-
-.glowOrbSecondary {
-  position: absolute;
-  width: 400px;
-  height: 400px;
-  border-radius: 50%;
-  background: radial-gradient(
-    circle at center,
-    rgba(37, 194, 160, 0.1) 0%,
-    rgba(37, 194, 160, 0.03) 40%,
-    transparent 70%
-  );
-  bottom: 15%;
-  left: -100px;
-  animation: breathe 18s ease-in-out infinite reverse;
-  will-change: opacity, transform;
-}
-
-/* ===== 极淡的网格线 ===== */
-.gridLines {
-  position: absolute;
-  inset: 0;
-  background-image: 
-    linear-gradient(rgba(46, 133, 85, 0.015) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(46, 133, 85, 0.015) 1px, transparent 1px);
-  background-size: 80px 80px;
-  mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    black 10%,
-    black 90%,
-    transparent 100%
-  );
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    black 10%,
-    black 90%,
-    transparent 100%
-  );
-}
-
-/* ===== 微妙的浮动点 ===== */
-.floatingDots {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-}
-
-.floatingDots::before,
-.floatingDots::after {
-  content: '';
-  position: absolute;
-  width: 4px;
-  height: 4px;
-  background: rgba(46, 133, 85, 0.2);
-  border-radius: 50%;
-  animation: floatUp 25s linear infinite;
-}
-
-.floatingDots::before {
-  left: 20%;
-  bottom: -10px;
-  animation-delay: 0s;
-}
-
-.floatingDots::after {
-  left: 80%;
-  bottom: -10px;
-  animation-delay: 12s;
-  width: 3px;
-  height: 3px;
-}
-
-/* ===== 装饰性圆环（极淡） ===== */
-.decorativeRing {
-  position: absolute;
-  width: 300px;
-  height: 300px;
-  border: 1px solid rgba(46, 133, 85, 0.06);
-  border-radius: 50%;
-  top: 30%;
-  right: 10%;
-  animation: rotate 60s linear infinite;
-  will-change: transform;
-}
-
-.decorativeRing::before {
-  content: '';
-  position: absolute;
-  inset: 30px;
-  border: 1px solid rgba(37, 194, 160, 0.04);
-  border-radius: 50%;
-}
-
-/* ===== 底部渐变遮罩（确保文字可读） ===== */
+.canvas,
+.editorialBlocks,
+.ruleLines,
+.cornerMarks,
 .readabilityMask {
   position: absolute;
   inset: 0;
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    transparent 60%,
-    rgba(255, 255, 255, 0.5) 100%
-  );
-  pointer-events: none;
 }
 
-/* ===== 动画定义 ===== */
-
-/* 呼吸效果 - 极缓慢 */
-@keyframes breathe {
-  0%, 100% {
-    opacity: 0.6;
-    transform: scale(1) translate(0, 0);
-  }
-  50% {
-    opacity: 1;
-    transform: scale(1.1) translate(-20px, 10px);
-  }
+.canvas {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(247, 250, 248, 0.98) 58%, rgba(239, 247, 243, 0.92) 100%),
+    repeating-linear-gradient(90deg, rgba(15, 23, 42, 0.022) 0 1px, transparent 1px 6px);
 }
 
-/* 向上浮动 */
-@keyframes floatUp {
-  0% {
-    transform: translateY(0) scale(1);
-    opacity: 0;
-  }
-  10% {
-    opacity: 0.6;
-  }
-  90% {
-    opacity: 0.6;
-  }
-  100% {
-    transform: translateY(-100vh) scale(0.5);
-    opacity: 0;
-  }
+.editorialBlocks {
+  background:
+    linear-gradient(90deg, rgba(46, 133, 85, 0.085) 0 7.5rem, transparent 7.5rem 100%),
+    linear-gradient(90deg, transparent 0 calc(100% - 10rem), rgba(37, 99, 123, 0.07) calc(100% - 10rem) 100%),
+    linear-gradient(180deg, transparent 0 18%, rgba(15, 23, 42, 0.035) 18.05% 18.2%, transparent 18.25% 100%),
+    linear-gradient(180deg, transparent 0 72%, rgba(46, 133, 85, 0.06) 72.05% 72.24%, transparent 72.3% 100%);
 }
 
-/* 缓慢旋转 */
-@keyframes rotate {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.ruleLines {
+  background:
+    linear-gradient(90deg, transparent 0 12%, rgba(15, 23, 42, 0.08) 12.05% 12.12%, transparent 12.18% 100%),
+    linear-gradient(90deg, transparent 0 44%, rgba(46, 133, 85, 0.06) 44.05% 44.13%, transparent 44.2% 100%),
+    linear-gradient(90deg, transparent 0 88%, rgba(37, 99, 123, 0.07) 88.05% 88.13%, transparent 88.2% 100%);
+  opacity: 0.72;
 }
 
-/* ===== 深色模式 ===== */
-[data-theme='dark'] .gradientBase {
-  background: 
-    radial-gradient(ellipse 80% 50% at 50% -20%, rgba(37, 194, 160, 0.06), transparent),
-    radial-gradient(ellipse 60% 40% at 80% 50%, rgba(46, 133, 85, 0.04), transparent),
-    radial-gradient(ellipse 50% 30% at 20% 80%, rgba(37, 194, 160, 0.05), transparent);
+.cornerMarks {
+  background:
+    linear-gradient(135deg, rgba(46, 133, 85, 0.16) 0 1px, transparent 1px 100%) 12% 18% / 11rem 11rem no-repeat,
+    linear-gradient(45deg, rgba(37, 99, 123, 0.13) 0 1px, transparent 1px 100%) 78% 64% / 14rem 14rem no-repeat,
+    repeating-linear-gradient(135deg, transparent 0 14px, rgba(46, 133, 85, 0.055) 14px 15px, transparent 15px 30px);
+  mask-image: linear-gradient(to bottom, #000 0%, #000 76%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 76%, transparent 100%);
 }
 
-[data-theme='dark'] .glowOrb {
-  background: radial-gradient(
-    circle at center,
-    rgba(37, 194, 160, 0.1) 0%,
-    rgba(37, 194, 160, 0.03) 40%,
-    transparent 70%
-  );
+.readabilityMask {
+  background:
+    linear-gradient(to right, rgba(252, 253, 252, 0.96) 0%, rgba(252, 253, 252, 0.68) 38%, transparent 66%),
+    linear-gradient(to bottom, rgba(252, 253, 252, 0.82) 0%, transparent 46%, rgba(252, 253, 252, 0.88) 100%);
 }
 
-[data-theme='dark'] .glowOrbSecondary {
-  background: radial-gradient(
-    circle at center,
-    rgba(46, 133, 85, 0.08) 0%,
-    rgba(46, 133, 85, 0.02) 40%,
-    transparent 70%
-  );
+[data-theme='dark'] .background {
+  background: #060b0a;
 }
 
-[data-theme='dark'] .gridLines {
-  background-image: 
-    linear-gradient(rgba(37, 194, 160, 0.01) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(37, 194, 160, 0.01) 1px, transparent 1px);
+[data-theme='dark'] .canvas {
+  background:
+    linear-gradient(180deg, rgba(5, 10, 9, 0.98) 0%, rgba(8, 15, 14, 0.96) 58%, rgba(5, 23, 20, 0.92) 100%),
+    repeating-linear-gradient(90deg, rgba(240, 253, 250, 0.022) 0 1px, transparent 1px 6px);
 }
 
-[data-theme='dark'] .floatingDots::before,
-[data-theme='dark'] .floatingDots::after {
-  background: rgba(37, 194, 160, 0.15);
+[data-theme='dark'] .editorialBlocks {
+  background:
+    linear-gradient(90deg, rgba(37, 194, 160, 0.095) 0 7.5rem, transparent 7.5rem 100%),
+    linear-gradient(90deg, transparent 0 calc(100% - 10rem), rgba(96, 165, 250, 0.075) calc(100% - 10rem) 100%),
+    linear-gradient(180deg, transparent 0 18%, rgba(240, 253, 250, 0.045) 18.05% 18.2%, transparent 18.25% 100%),
+    linear-gradient(180deg, transparent 0 72%, rgba(37, 194, 160, 0.075) 72.05% 72.24%, transparent 72.3% 100%);
 }
 
-[data-theme='dark'] .decorativeRing {
-  border-color: rgba(37, 194, 160, 0.05);
+[data-theme='dark'] .ruleLines {
+  background:
+    linear-gradient(90deg, transparent 0 12%, rgba(240, 253, 250, 0.08) 12.05% 12.12%, transparent 12.18% 100%),
+    linear-gradient(90deg, transparent 0 44%, rgba(37, 194, 160, 0.07) 44.05% 44.13%, transparent 44.2% 100%),
+    linear-gradient(90deg, transparent 0 88%, rgba(96, 165, 250, 0.08) 88.05% 88.13%, transparent 88.2% 100%);
 }
 
-[data-theme='dark'] .decorativeRing::before {
-  border-color: rgba(46, 133, 85, 0.03);
+[data-theme='dark'] .cornerMarks {
+  background:
+    linear-gradient(135deg, rgba(37, 194, 160, 0.18) 0 1px, transparent 1px 100%) 12% 18% / 11rem 11rem no-repeat,
+    linear-gradient(45deg, rgba(96, 165, 250, 0.14) 0 1px, transparent 1px 100%) 78% 64% / 14rem 14rem no-repeat,
+    repeating-linear-gradient(135deg, transparent 0 14px, rgba(37, 194, 160, 0.055) 14px 15px, transparent 15px 30px);
 }
 
 [data-theme='dark'] .readabilityMask {
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    transparent 60%,
-    rgba(0, 0, 0, 0.3) 100%
-  );
+  background:
+    linear-gradient(to right, rgba(6, 11, 10, 0.96) 0%, rgba(6, 11, 10, 0.68) 38%, transparent 66%),
+    linear-gradient(to bottom, rgba(6, 11, 10, 0.82) 0%, transparent 46%, rgba(6, 11, 10, 0.9) 100%);
 }
 
-/* ===== 减少动画偏好 ===== */
-@media (prefers-reduced-motion: reduce) {
-  .glowOrb,
-  .glowOrbSecondary {
-    animation: none;
-    opacity: 0.8;
-  }
-  
-  .decorativeRing {
-    animation: none;
-  }
-  
-  .floatingDots::before,
-  .floatingDots::after {
-    animation: none;
-    opacity: 0;
-  }
-}
-
-/* ===== 移动端优化 ===== */
 @media (max-width: 768px) {
-  .glowOrb {
-    width: 300px;
-    height: 300px;
-    right: -100px;
-    opacity: 0.7;
+  .editorialBlocks {
+    background:
+      linear-gradient(90deg, rgba(46, 133, 85, 0.08) 0 1.5rem, transparent 1.5rem 100%),
+      linear-gradient(180deg, transparent 0 20%, rgba(15, 23, 42, 0.035) 20.05% 20.24%, transparent 20.3% 100%);
   }
-  
-  .glowOrbSecondary {
-    width: 250px;
-    height: 250px;
-    left: -80px;
-    opacity: 0.6;
-  }
-  
-  .decorativeRing {
-    display: none;
-  }
-  
-  .gridLines {
-    background-size: 60px 60px;
-  }
-  
-  .floatingDots::before,
-  .floatingDots::after {
-    display: none;
+
+  .cornerMarks {
+    opacity: 0.45;
   }
 }

--- a/src/components/Homepage/Hero/styles.module.css
+++ b/src/components/Homepage/Hero/styles.module.css
@@ -109,11 +109,19 @@
 }
 
 .circle {
-  @apply absolute top-0 w-full h-full bg-gradient-to-r from-[rgb(150,255,244,0.81)] to-[rgb(0,71,252,0.81)] rounded-full opacity-30;
-  filter: blur(80px);
+  @apply absolute top-[9%] w-[78%] h-[78%] rounded-[8px] opacity-90;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(240, 248, 244, 0.42)),
+    repeating-linear-gradient(90deg, rgba(46, 133, 85, 0.08) 0 1px, transparent 1px 22px);
+  border: 1px solid rgba(46, 133, 85, 0.16);
   z-index: -1;
-  will-change: transform;
-  transform: translateZ(0); /* 启用 GPU 加速 */
+}
+
+[data-theme='dark'] .circle {
+  background:
+    linear-gradient(180deg, rgba(10, 25, 21, 0.72), rgba(5, 18, 16, 0.42)),
+    repeating-linear-gradient(90deg, rgba(37, 194, 160, 0.1) 0 1px, transparent 1px 22px);
+  border-color: rgba(37, 194, 160, 0.18);
 }
 
 .button_text {


### PR DESCRIPTION
## Summary

- Replaces the animated glow-orb homepage background with a static editorial canvas.
- Removes the blurred gradient circle behind the hero image and uses a crisp rectangular pattern panel.
- Keeps the background CSS/TSX-only with no runtime JavaScript state or continuous animation.

## Design direction

Option B is the calmest and most reading-first direction: subtle side rails, page-rule lines, corner marks, and a light texture. It aims to feel polished and modern without competing with the homepage content.

## Validation

- `npm run typecheck`
- `npm run build`

Note: build completed with existing `vscode-languageserver-types` critical dependency warnings.