### PR TITLE
[codex] homepage background option C: knowledge map

### DIFF
--- a/src/components/Homepage/BackgroundEffects/index.tsx
+++ b/src/components/Homepage/BackgroundEffects/index.tsx
@@ -1,32 +1,13 @@
 import { memo } from 'react';
 import styles from './styles.module.css';
 
-/**
- * 优化版 CSS 背景效果
- * - 柔和渐变，不干扰阅读
- * - 缓慢呼吸动画，增加动态感
- * - 底部遮罩确保文字可读性
- */
 function BackgroundEffects() {
   return (
     <div className={styles.background} aria-hidden="true">
-      {/* 基础渐变背景 */}
-      <div className={styles.gradientBase} />
-      
-      {/* 呼吸光晕 */}
-      <div className={styles.glowOrb} />
-      <div className={styles.glowOrbSecondary} />
-      
-      {/* 极淡网格 */}
-      <div className={styles.gridLines} />
-      
-      {/* 微妙浮动点 */}
-      <div className={styles.floatingDots} />
-      
-      {/* 装饰圆环 */}
-      <div className={styles.decorativeRing} />
-      
-      {/* 可读性遮罩 */}
+      <div className={styles.surface} />
+      <div className={styles.matrix} />
+      <div className={styles.routes} />
+      <div className={styles.moduleMarks} />
       <div className={styles.readabilityMask} />
     </div>
   );

--- a/src/components/Homepage/BackgroundEffects/styles.module.css
+++ b/src/components/Homepage/BackgroundEffects/styles.module.css
@@ -1,289 +1,115 @@
-/* 优化版 CSS 背景效果 - 动态但不干扰阅读 */
-
 .background {
   position: fixed;
   inset: 0;
   pointer-events: none;
   z-index: -1;
   overflow: hidden;
+  background: #fbfcfd;
 }
 
-/* ===== 柔和渐变背景 ===== */
-.gradientBase {
-  position: absolute;
-  inset: 0;
-  background: 
-    radial-gradient(ellipse 80% 50% at 50% -20%, rgba(46, 133, 85, 0.08), transparent),
-    radial-gradient(ellipse 60% 40% at 80% 50%, rgba(37, 194, 160, 0.05), transparent),
-    radial-gradient(ellipse 50% 30% at 20% 80%, rgba(46, 133, 85, 0.06), transparent);
-}
-
-/* ===== 缓慢呼吸的光晕 ===== */
-.glowOrb {
-  position: absolute;
-  width: 500px;
-  height: 500px;
-  border-radius: 50%;
-  background: radial-gradient(
-    circle at center,
-    rgba(46, 133, 85, 0.12) 0%,
-    rgba(46, 133, 85, 0.04) 40%,
-    transparent 70%
-  );
-  top: 10%;
-  right: -150px;
-  animation: breathe 15s ease-in-out infinite;
-  will-change: opacity, transform;
-}
-
-.glowOrbSecondary {
-  position: absolute;
-  width: 400px;
-  height: 400px;
-  border-radius: 50%;
-  background: radial-gradient(
-    circle at center,
-    rgba(37, 194, 160, 0.1) 0%,
-    rgba(37, 194, 160, 0.03) 40%,
-    transparent 70%
-  );
-  bottom: 15%;
-  left: -100px;
-  animation: breathe 18s ease-in-out infinite reverse;
-  will-change: opacity, transform;
-}
-
-/* ===== 极淡的网格线 ===== */
-.gridLines {
-  position: absolute;
-  inset: 0;
-  background-image: 
-    linear-gradient(rgba(46, 133, 85, 0.015) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(46, 133, 85, 0.015) 1px, transparent 1px);
-  background-size: 80px 80px;
-  mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    black 10%,
-    black 90%,
-    transparent 100%
-  );
-  -webkit-mask-image: linear-gradient(
-    to bottom,
-    transparent 0%,
-    black 10%,
-    black 90%,
-    transparent 100%
-  );
-}
-
-/* ===== 微妙的浮动点 ===== */
-.floatingDots {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-}
-
-.floatingDots::before,
-.floatingDots::after {
-  content: '';
-  position: absolute;
-  width: 4px;
-  height: 4px;
-  background: rgba(46, 133, 85, 0.2);
-  border-radius: 50%;
-  animation: floatUp 25s linear infinite;
-}
-
-.floatingDots::before {
-  left: 20%;
-  bottom: -10px;
-  animation-delay: 0s;
-}
-
-.floatingDots::after {
-  left: 80%;
-  bottom: -10px;
-  animation-delay: 12s;
-  width: 3px;
-  height: 3px;
-}
-
-/* ===== 装饰性圆环（极淡） ===== */
-.decorativeRing {
-  position: absolute;
-  width: 300px;
-  height: 300px;
-  border: 1px solid rgba(46, 133, 85, 0.06);
-  border-radius: 50%;
-  top: 30%;
-  right: 10%;
-  animation: rotate 60s linear infinite;
-  will-change: transform;
-}
-
-.decorativeRing::before {
-  content: '';
-  position: absolute;
-  inset: 30px;
-  border: 1px solid rgba(37, 194, 160, 0.04);
-  border-radius: 50%;
-}
-
-/* ===== 底部渐变遮罩（确保文字可读） ===== */
+.surface,
+.matrix,
+.routes,
+.moduleMarks,
 .readabilityMask {
   position: absolute;
   inset: 0;
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    transparent 60%,
-    rgba(255, 255, 255, 0.5) 100%
-  );
-  pointer-events: none;
 }
 
-/* ===== 动画定义 ===== */
-
-/* 呼吸效果 - 极缓慢 */
-@keyframes breathe {
-  0%, 100% {
-    opacity: 0.6;
-    transform: scale(1) translate(0, 0);
-  }
-  50% {
-    opacity: 1;
-    transform: scale(1.1) translate(-20px, 10px);
-  }
+.surface {
+  background:
+    linear-gradient(126deg, rgba(255, 255, 255, 0.98) 0%, rgba(246, 251, 249, 0.94) 48%, rgba(242, 248, 252, 0.88) 100%),
+    repeating-linear-gradient(0deg, rgba(15, 23, 42, 0.02) 0 1px, transparent 1px 5px);
 }
 
-/* 向上浮动 */
-@keyframes floatUp {
-  0% {
-    transform: translateY(0) scale(1);
-    opacity: 0;
-  }
-  10% {
-    opacity: 0.6;
-  }
-  90% {
-    opacity: 0.6;
-  }
-  100% {
-    transform: translateY(-100vh) scale(0.5);
-    opacity: 0;
-  }
+.matrix {
+  background-image:
+    linear-gradient(rgba(46, 133, 85, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(37, 99, 123, 0.04) 1px, transparent 1px);
+  background-size: 40px 40px;
+  mask-image: linear-gradient(to bottom, transparent 0%, #000 10%, #000 70%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to bottom, transparent 0%, #000 10%, #000 70%, transparent 100%);
 }
 
-/* 缓慢旋转 */
-@keyframes rotate {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.routes {
+  background:
+    linear-gradient(90deg, transparent 0 52%, rgba(46, 133, 85, 0.12) 52.05% 52.18%, transparent 52.25% 100%),
+    linear-gradient(0deg, transparent 0 34%, rgba(37, 99, 123, 0.11) 34.05% 34.18%, transparent 34.25% 100%),
+    linear-gradient(90deg, transparent 0 78%, rgba(15, 23, 42, 0.08) 78.05% 78.16%, transparent 78.24% 100%),
+    linear-gradient(0deg, transparent 0 58%, rgba(46, 133, 85, 0.08) 58.05% 58.16%, transparent 58.24% 100%);
 }
 
-/* ===== 深色模式 ===== */
-[data-theme='dark'] .gradientBase {
-  background: 
-    radial-gradient(ellipse 80% 50% at 50% -20%, rgba(37, 194, 160, 0.06), transparent),
-    radial-gradient(ellipse 60% 40% at 80% 50%, rgba(46, 133, 85, 0.04), transparent),
-    radial-gradient(ellipse 50% 30% at 20% 80%, rgba(37, 194, 160, 0.05), transparent);
+.moduleMarks {
+  background:
+    linear-gradient(90deg, rgba(46, 133, 85, 0.18) 0 4.8rem, transparent 4.8rem) 55% 34% / 9rem 1px no-repeat,
+    linear-gradient(90deg, rgba(37, 99, 123, 0.16) 0 3.4rem, transparent 3.4rem) 78% 58% / 7rem 1px no-repeat,
+    linear-gradient(90deg, rgba(15, 23, 42, 0.14) 0 4rem, transparent 4rem) 33% 22% / 8rem 1px no-repeat,
+    linear-gradient(0deg, rgba(46, 133, 85, 0.2) 0 2.7rem, transparent 2.7rem) 52% 34% / 1px 5rem no-repeat,
+    linear-gradient(0deg, rgba(37, 99, 123, 0.18) 0 2.2rem, transparent 2.2rem) 78% 58% / 1px 4rem no-repeat,
+    linear-gradient(135deg, rgba(46, 133, 85, 0.12) 0 1px, transparent 1px 100%) 52% 34% / 5.5rem 5.5rem no-repeat,
+    linear-gradient(135deg, rgba(37, 99, 123, 0.1) 0 1px, transparent 1px 100%) 78% 58% / 5rem 5rem no-repeat,
+    repeating-linear-gradient(90deg, transparent 0 24px, rgba(46, 133, 85, 0.045) 24px 25px, transparent 25px 48px);
+  opacity: 0.86;
 }
 
-[data-theme='dark'] .glowOrb {
-  background: radial-gradient(
-    circle at center,
-    rgba(37, 194, 160, 0.1) 0%,
-    rgba(37, 194, 160, 0.03) 40%,
-    transparent 70%
-  );
+.readabilityMask {
+  background:
+    linear-gradient(to right, rgba(251, 252, 253, 0.96) 0%, rgba(251, 252, 253, 0.64) 42%, transparent 72%),
+    linear-gradient(to bottom, rgba(251, 252, 253, 0.78) 0%, transparent 42%, rgba(251, 252, 253, 0.86) 100%);
 }
 
-[data-theme='dark'] .glowOrbSecondary {
-  background: radial-gradient(
-    circle at center,
-    rgba(46, 133, 85, 0.08) 0%,
-    rgba(46, 133, 85, 0.02) 40%,
-    transparent 70%
-  );
+[data-theme='dark'] .background {
+  background: #06100f;
 }
 
-[data-theme='dark'] .gridLines {
-  background-image: 
-    linear-gradient(rgba(37, 194, 160, 0.01) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(37, 194, 160, 0.01) 1px, transparent 1px);
+[data-theme='dark'] .surface {
+  background:
+    linear-gradient(126deg, rgba(5, 11, 10, 0.98) 0%, rgba(7, 16, 14, 0.96) 48%, rgba(7, 16, 23, 0.9) 100%),
+    repeating-linear-gradient(0deg, rgba(240, 253, 250, 0.02) 0 1px, transparent 1px 5px);
 }
 
-[data-theme='dark'] .floatingDots::before,
-[data-theme='dark'] .floatingDots::after {
-  background: rgba(37, 194, 160, 0.15);
+[data-theme='dark'] .matrix {
+  background-image:
+    linear-gradient(rgba(37, 194, 160, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(96, 165, 250, 0.045) 1px, transparent 1px);
 }
 
-[data-theme='dark'] .decorativeRing {
-  border-color: rgba(37, 194, 160, 0.05);
+[data-theme='dark'] .routes {
+  background:
+    linear-gradient(90deg, transparent 0 52%, rgba(37, 194, 160, 0.14) 52.05% 52.18%, transparent 52.25% 100%),
+    linear-gradient(0deg, transparent 0 34%, rgba(96, 165, 250, 0.11) 34.05% 34.18%, transparent 34.25% 100%),
+    linear-gradient(90deg, transparent 0 78%, rgba(240, 253, 250, 0.08) 78.05% 78.16%, transparent 78.24% 100%),
+    linear-gradient(0deg, transparent 0 58%, rgba(37, 194, 160, 0.09) 58.05% 58.16%, transparent 58.24% 100%);
 }
 
-[data-theme='dark'] .decorativeRing::before {
-  border-color: rgba(46, 133, 85, 0.03);
+[data-theme='dark'] .moduleMarks {
+  background:
+    linear-gradient(90deg, rgba(37, 194, 160, 0.2) 0 4.8rem, transparent 4.8rem) 55% 34% / 9rem 1px no-repeat,
+    linear-gradient(90deg, rgba(96, 165, 250, 0.17) 0 3.4rem, transparent 3.4rem) 78% 58% / 7rem 1px no-repeat,
+    linear-gradient(90deg, rgba(240, 253, 250, 0.14) 0 4rem, transparent 4rem) 33% 22% / 8rem 1px no-repeat,
+    linear-gradient(0deg, rgba(37, 194, 160, 0.22) 0 2.7rem, transparent 2.7rem) 52% 34% / 1px 5rem no-repeat,
+    linear-gradient(0deg, rgba(96, 165, 250, 0.18) 0 2.2rem, transparent 2.2rem) 78% 58% / 1px 4rem no-repeat,
+    linear-gradient(135deg, rgba(37, 194, 160, 0.13) 0 1px, transparent 1px 100%) 52% 34% / 5.5rem 5.5rem no-repeat,
+    linear-gradient(135deg, rgba(96, 165, 250, 0.11) 0 1px, transparent 1px 100%) 78% 58% / 5rem 5rem no-repeat,
+    repeating-linear-gradient(90deg, transparent 0 24px, rgba(37, 194, 160, 0.05) 24px 25px, transparent 25px 48px);
 }
 
 [data-theme='dark'] .readabilityMask {
-  background: linear-gradient(
-    to bottom,
-    transparent 0%,
-    transparent 60%,
-    rgba(0, 0, 0, 0.3) 100%
-  );
+  background:
+    linear-gradient(to right, rgba(6, 16, 15, 0.96) 0%, rgba(6, 16, 15, 0.64) 42%, transparent 72%),
+    linear-gradient(to bottom, rgba(6, 16, 15, 0.78) 0%, transparent 42%, rgba(6, 16, 15, 0.88) 100%);
 }
 
-/* ===== 减少动画偏好 ===== */
-@media (prefers-reduced-motion: reduce) {
-  .glowOrb,
-  .glowOrbSecondary {
-    animation: none;
-    opacity: 0.8;
-  }
-  
-  .decorativeRing {
-    animation: none;
-  }
-  
-  .floatingDots::before,
-  .floatingDots::after {
-    animation: none;
-    opacity: 0;
-  }
-}
-
-/* ===== 移动端优化 ===== */
 @media (max-width: 768px) {
-  .glowOrb {
-    width: 300px;
-    height: 300px;
-    right: -100px;
-    opacity: 0.7;
+  .matrix {
+    background-size: 32px 32px;
   }
-  
-  .glowOrbSecondary {
-    width: 250px;
-    height: 250px;
-    left: -80px;
-    opacity: 0.6;
-  }
-  
-  .decorativeRing {
-    display: none;
-  }
-  
-  .gridLines {
-    background-size: 60px 60px;
-  }
-  
-  .floatingDots::before,
-  .floatingDots::after {
-    display: none;
+
+  .moduleMarks {
+    opacity: 0.48;
+    background:
+      linear-gradient(90deg, rgba(46, 133, 85, 0.16) 0 4rem, transparent 4rem) 70% 45% / 7rem 1px no-repeat,
+      linear-gradient(0deg, rgba(37, 99, 123, 0.16) 0 2rem, transparent 2rem) 70% 45% / 1px 4rem no-repeat,
+      repeating-linear-gradient(90deg, transparent 0 20px, rgba(46, 133, 85, 0.04) 20px 21px, transparent 21px 40px);
   }
 }

--- a/src/components/Homepage/Hero/styles.module.css
+++ b/src/components/Homepage/Hero/styles.module.css
@@ -109,11 +109,23 @@
 }
 
 .circle {
-  @apply absolute top-0 w-full h-full bg-gradient-to-r from-[rgb(150,255,244,0.81)] to-[rgb(0,71,252,0.81)] rounded-full opacity-30;
-  filter: blur(80px);
+  @apply absolute top-[5%] w-[84%] h-[84%] rounded-[10px] opacity-85;
+  background:
+    linear-gradient(135deg, rgba(46, 133, 85, 0.1), transparent 42%),
+    linear-gradient(90deg, transparent 0 48%, rgba(46, 133, 85, 0.12) 48.1% 48.35%, transparent 48.5% 100%),
+    linear-gradient(0deg, transparent 0 46%, rgba(37, 99, 123, 0.1) 46.1% 46.35%, transparent 46.5% 100%),
+    repeating-linear-gradient(0deg, rgba(15, 23, 42, 0.05) 0 1px, transparent 1px 20px);
+  border: 1px solid rgba(46, 133, 85, 0.14);
   z-index: -1;
-  will-change: transform;
-  transform: translateZ(0); /* 启用 GPU 加速 */
+}
+
+[data-theme='dark'] .circle {
+  background:
+    linear-gradient(135deg, rgba(37, 194, 160, 0.11), transparent 42%),
+    linear-gradient(90deg, transparent 0 48%, rgba(37, 194, 160, 0.14) 48.1% 48.35%, transparent 48.5% 100%),
+    linear-gradient(0deg, transparent 0 46%, rgba(96, 165, 250, 0.11) 46.1% 46.35%, transparent 46.5% 100%),
+    repeating-linear-gradient(0deg, rgba(240, 253, 250, 0.05) 0 1px, transparent 1px 20px);
+  border-color: rgba(37, 194, 160, 0.16);
 }
 
 .button_text {


### PR DESCRIPTION
## Summary

- Replaces the animated glow-orb homepage background with a static knowledge-map style composition.
- Removes the blurred gradient hero circle and swaps in a lightweight route/grid panel.
- Keeps the effect CSS/TSX-only with no runtime JavaScript state or continuous animation.

## Design direction

Option C is the most distinctive option: route lines, module marks, and a sparse matrix suggest a technical knowledge map. It is meant to create a stronger first-screen memory point while still protecting text readability.

## Validation

- `npm run typecheck`
- `npm run build`

Note: build completed with existing `vscode-languageserver-types` critical dependency warnings.