### PR TITLE
refactor: share article action buttons

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -210,6 +210,9 @@
     "message": "Edit this page",
     "description": "The link label to edit the current page"
   },
+  "theme.common.back": {
+    "message": "Back"
+  },
   "theme.common.headingLinkTitle": {
     "message": "Direct link to {heading}",
     "description": "Title for link to heading"

--- a/src/components/ActionButton/index.tsx
+++ b/src/components/ActionButton/index.tsx
@@ -1,0 +1,75 @@
+import React, {
+  type ButtonHTMLAttributes,
+  type MouseEventHandler,
+  type ReactNode,
+} from 'react';
+import Link from '@docusaurus/Link';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+type IconPosition = 'start' | 'end';
+
+interface BaseActionButtonProps {
+  children: ReactNode;
+  className?: string;
+  icon?: ReactNode;
+  iconPosition?: IconPosition;
+  stretch?: boolean;
+  ariaLabel?: string;
+}
+
+interface ActionButtonLinkProps extends BaseActionButtonProps {
+  to: string;
+  onClick?: never;
+  type?: never;
+}
+
+interface ActionButtonButtonProps extends BaseActionButtonProps {
+  to?: never;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
+}
+
+export type ActionButtonProps = ActionButtonLinkProps | ActionButtonButtonProps;
+
+export function ActionButton({
+  children,
+  className,
+  icon,
+  iconPosition = 'end',
+  stretch = false,
+  ariaLabel,
+  ...props
+}: ActionButtonProps): ReactNode {
+  const content = (
+    <>
+      {iconPosition === 'start' && icon}
+      <span>{children}</span>
+      {iconPosition === 'end' && icon}
+    </>
+  );
+  const buttonClassName = clsx(
+    styles.button,
+    stretch && styles.stretch,
+    className,
+  );
+
+  if ('to' in props && props.to) {
+    return (
+      <Link to={props.to} className={buttonClassName} aria-label={ariaLabel}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type={props.type ?? 'button'}
+      className={buttonClassName}
+      aria-label={ariaLabel}
+      onClick={props.onClick}
+    >
+      {content}
+    </button>
+  );
+}

--- a/src/components/ActionButton/styles.module.css
+++ b/src/components/ActionButton/styles.module.css
@@ -1,0 +1,71 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 2.75rem;
+  padding: 0.625rem 1.5rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 9999px;
+  background: transparent;
+  color: var(--ifm-color-primary);
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.button:hover {
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-primary);
+  color: #fff;
+  text-decoration: none;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(46, 133, 85, 0.2);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+  outline-offset: 3px;
+}
+
+.button:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.button svg {
+  flex-shrink: 0;
+}
+
+.stretch {
+  width: 100%;
+}
+
+@media (max-width: 768px) {
+  .button {
+    min-width: 0;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.8125rem;
+    gap: 0.375rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button {
+    transition: none;
+  }
+
+  .button:hover,
+  .button:active {
+    transform: none;
+  }
+}

--- a/src/components/BackButton/index.tsx
+++ b/src/components/BackButton/index.tsx
@@ -1,0 +1,50 @@
+import React, { type ReactNode } from 'react';
+import Translate, { translate } from '@docusaurus/Translate';
+import { useHistory } from '@docusaurus/router';
+import clsx from 'clsx';
+import { ArrowLeft } from 'lucide-react';
+import { ActionButton } from '@site/src/components/ActionButton';
+import styles from './styles.module.css';
+
+interface BackButtonProps {
+  className?: string;
+  fallbackTo?: string;
+  label?: ReactNode;
+}
+
+export function BackButton({
+  className,
+  fallbackTo = '/',
+  label,
+}: BackButtonProps): ReactNode {
+  const history = useHistory();
+
+  const handleClick = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      history.goBack();
+      return;
+    }
+
+    history.push(fallbackTo);
+  };
+
+  return (
+    <div className={clsx(styles.wrapper, className)}>
+      <ActionButton
+        ariaLabel={translate({
+          id: 'theme.common.back',
+          message: '返回',
+        })}
+        icon={<ArrowLeft size={16} aria-hidden="true" />}
+        iconPosition="start"
+        onClick={handleClick}
+      >
+        {label ?? (
+          <Translate id="theme.common.back">
+            返回
+          </Translate>
+        )}
+      </ActionButton>
+    </div>
+  );
+}

--- a/src/components/BackButton/styles.module.css
+++ b/src/components/BackButton/styles.module.css
@@ -1,0 +1,5 @@
+.wrapper {
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}

--- a/src/components/Homepage/LatestArticles/index.tsx
+++ b/src/components/Homepage/LatestArticles/index.tsx
@@ -2,6 +2,7 @@ import { memo, type CSSProperties } from 'react';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
 import { usePluginData } from '@docusaurus/useGlobalData';
+import { ActionButton } from '@site/src/components/ActionButton';
 import { ArrowRight, Sparkles } from 'lucide-react';
 import styles from './styles.module.css';
 
@@ -161,14 +162,12 @@ function LatestArticles() {
         )}
 
         <div className={styles.footer}>
-          <Link to="/docs" className={styles.viewAllLink}>
+          <ActionButton to="/docs" icon={<ArrowRight size={16} aria-hidden="true" />}>
             <Translate id="homepage.latestArticles.viewAllDocs">View All Docs</Translate>
-            <ArrowRight size={16} />
-          </Link>
-          <Link to="/blog" className={styles.viewAllLink}>
+          </ActionButton>
+          <ActionButton to="/blog" icon={<ArrowRight size={16} aria-hidden="true" />}>
             <Translate id="homepage.latestArticles.viewAllBlog">View All Blogs</Translate>
-            <ArrowRight size={16} />
-          </Link>
+          </ActionButton>
         </div>
       </div>
     </section>

--- a/src/components/Homepage/LatestArticles/styles.module.css
+++ b/src/components/Homepage/LatestArticles/styles.module.css
@@ -258,22 +258,6 @@
   @apply mt-12 flex flex-wrap justify-center gap-4;
 }
 
-.viewAllLink {
-  @apply inline-flex items-center gap-2 rounded-full px-6 py-2.5 text-sm font-medium transition-all duration-200;
-  background: transparent;
-  color: var(--ifm-color-primary);
-  border: 1px solid var(--ifm-color-emphasis-300);
-  text-decoration: none;
-}
-
-.viewAllLink:hover {
-  background: var(--ifm-color-primary);
-  color: #fff;
-  border-color: var(--ifm-color-primary);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(46, 133, 85, 0.2);
-}
-
 .emptyState {
   @apply py-12 text-center;
   color: var(--ifm-color-emphasis-500);
@@ -295,11 +279,5 @@
 
   .footer {
     @apply mt-10 grid grid-cols-2 gap-3;
-  }
-
-  .viewAllLink {
-    @apply justify-center px-3 py-2 text-[13px];
-    gap: 0.375rem;
-    min-width: 0;
   }
 }

--- a/src/pages/docs/index.tsx
+++ b/src/pages/docs/index.tsx
@@ -3,6 +3,7 @@ import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
 import Translate from '@docusaurus/Translate';
 import { usePluginData } from '@docusaurus/useGlobalData';
+import { BackButton } from '@site/src/components/BackButton';
 import { FileText, ArrowRight, Code, Server, Cpu, Settings, Database, Smartphone, Shield, Globe, Terminal, Cloud } from 'lucide-react';
 import styles from './styles.module.css';
 
@@ -128,6 +129,7 @@ export default function DocsIndexPage(): ReactNode {
               </Translate>
             </p>
           </div>
+          <BackButton />
         </div>
       </div>
     </Layout>

--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -11,6 +11,7 @@ import Link from '@docusaurus/Link';
 import Layout from '@theme/Layout';
 import Translate from '@docusaurus/Translate';
 import SearchMetadata from '@theme/SearchMetadata';
+import { BackButton } from '@site/src/components/BackButton';
 import type { Props } from '@theme/BlogListPage';
 import BlogListPageStructuredData from '@theme/BlogListPage/StructuredData';
 import { Calendar, ArrowRight, Tag, Clock } from 'lucide-react';
@@ -177,6 +178,7 @@ function BlogListPageContent(props: Props): ReactNode {
               )}
             </nav>
           )}
+          <BackButton />
         </div>
       </div>
     </Layout>


### PR DESCRIPTION
## Summary

- Extract the homepage pill-style article action link into a shared `ActionButton` component.
- Add a `BackButton` wrapper that reuses the shared button style with a left arrow and browser-history behavior.
- Reuse the shared button on the homepage `/docs` and `/blog` entry links, plus the `/docs` and `/blog` middle pages.

## Validation

- `npm run typecheck`
- `Get-ChildItem -Path src -Recurse -Filter *.test.js | ForEach-Object { node --test $_.FullName }`
- `npm run build`

Note: the production build still reports the existing `vscode-languageserver-types` critical dependency warning, but exits successfully.